### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
 	f["requestClientApplication"] = "Go-http-client/1.1"
 
 	event := cefevent.CefEvent{
-		Version:            "0",
+		Version:            0,
 		DeviceVendor:       "Cool Vendor",
 		DeviceProduct:      "Cool Product",
 		DeviceVersion:      "1.0",


### PR DESCRIPTION
in the example, the Version field is an int variable, and you provided a string, therefore when you run the code you get the following error:
15:3: cannot use "0" (type untyped string) as type int in field value

Changing it to a int, fix the issue.